### PR TITLE
二度寝検知システムを実装

### DIFF
--- a/app/monitoring/page.tsx
+++ b/app/monitoring/page.tsx
@@ -2,13 +2,15 @@
 
 import { useRouter } from "next/navigation";
 
-import { useAlarmStore } from "@/stores/alarmStore";
+import { type AlarmStore, useAlarmStore } from "@/stores/alarmStore";
+import { useSleepDetection } from "@/components/useSleepDetection";
 
 export default function MonitoringPage() {
   const router = useRouter();
-  const state = useAlarmStore((store) => store.state);
-  const transition = useAlarmStore((store) => store.transition);
-  const reset = useAlarmStore((store) => store.reset);
+  const state = useAlarmStore((store: AlarmStore) => store.state);
+  const isSleepDetectionOn = useAlarmStore((store: AlarmStore) => store.isSleepDetectionOn);
+  const transition = useAlarmStore((store: AlarmStore) => store.transition);
+  const reset = useAlarmStore((store: AlarmStore) => store.reset);
 
   const clearChallenge = () => {
     const moved = transition("cleared");
@@ -22,10 +24,51 @@ export default function MonitoringPage() {
     router.push("/");
   };
 
+  const handleSleepDetected = () => {
+    if (state !== "penalty") {
+      transition("penalty");
+    }
+  };
+
+  const handleAwakeDetected = () => {
+    if (state === "penalty") {
+      transition("monitoring");
+    }
+  };
+
+  const { videoRef, isInitializing } = useSleepDetection(
+    handleSleepDetected,
+    handleAwakeDetected
+  );
+
   return (
     <main className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center gap-6 px-6 text-center">
       <h1 className="text-3xl font-bold">Monitoring</h1>
       <p className="text-sm opacity-70">/monitoring</p>
+
+      {isSleepDetectionOn && (
+        <div className="relative w-64 h-48 bg-black rounded-lg overflow-hidden border-2 border-slate-700 shadow-md">
+          <video
+            ref={videoRef}
+            className="w-full h-full object-cover"
+            playsInline
+            autoPlay
+            muted
+          />
+          {isInitializing && (
+            <div className="absolute inset-0 flex items-center justify-center bg-black/50 text-white text-sm">
+              Initializing AI...
+            </div>
+          )}
+        </div>
+      )}
+
+      {state === "penalty" && (
+        <div className="animate-pulse bg-red-500/20 border-2 border-red-500 text-red-600 font-bold px-6 py-4 rounded-xl shadow-lg mt-4 w-full max-w-sm">
+          ⚠️ 起きてください！二度寝を検知しました！ ⚠️
+        </div>
+      )}
+
       <p className="text-lg">
         Current state: <span className="font-semibold">{state}</span>
       </p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,13 +2,15 @@
 
 import { useRouter } from "next/navigation";
 
-import { useAlarmStore } from "@/stores/alarmStore";
+import { type AlarmStore, useAlarmStore } from "@/stores/alarmStore";
 
 export default function HomePage() {
   const router = useRouter();
-  const state = useAlarmStore((store) => store.state);
-  const transition = useAlarmStore((store) => store.transition);
-  const reset = useAlarmStore((store) => store.reset);
+  const state = useAlarmStore((store: AlarmStore) => store.state);
+  const isSleepDetectionOn = useAlarmStore((store: AlarmStore) => store.isSleepDetectionOn);
+  const setSleepDetectionOn = useAlarmStore((store: AlarmStore) => store.setSleepDetectionOn);
+  const transition = useAlarmStore((store: AlarmStore) => store.transition);
+  const reset = useAlarmStore((store: AlarmStore) => store.reset);
   const isDev = process.env.NODE_ENV !== "production";
 
   const startWaiting = () => {
@@ -31,6 +33,22 @@ export default function HomePage() {
     }
   };
 
+  const handleToggleSleepDetection = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const checked = e.target.checked;
+    if (checked) {
+      try {
+        await navigator.mediaDevices.getUserMedia({ video: true });
+        setSleepDetectionOn(true);
+      } catch (err) {
+        console.error("Camera permission denied:", err);
+        setSleepDetectionOn(false);
+        alert("カメラの許可が得られなかったため、二度寝検知機能をOFFにします。");
+      }
+    } else {
+      setSleepDetectionOn(false);
+    }
+  };
+
   return (
     <main className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center gap-6 px-6 text-center">
       <h1 className="text-3xl font-bold">目覚ましクソコード</h1>
@@ -44,6 +62,19 @@ export default function HomePage() {
           Challenge cleared. 次の目覚ましを開始できます。
         </p>
       )}
+
+      <div className="flex items-center gap-2 mb-4">
+        <input
+          type="checkbox"
+          id="sleep-detection-toggle"
+          checked={isSleepDetectionOn}
+          onChange={handleToggleSleepDetection}
+          className="h-5 w-5 rounded border-gray-300"
+        />
+        <label htmlFor="sleep-detection-toggle" className="text-sm cursor-pointer select-none">
+          二度寝検知機能 (カメラ使用)
+        </label>
+      </div>
 
       <div className="flex gap-3">
         <button

--- a/components/useSleepDetection.ts
+++ b/components/useSleepDetection.ts
@@ -1,0 +1,118 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { FaceLandmarker, FilesetResolver } from "@mediapipe/tasks-vision";
+
+export function useSleepDetection(onSleepDetected: () => void, onAwakeDetected: () => void) {
+    const videoRef = useRef<HTMLVideoElement>(null);
+    const landmarkerRef = useRef<FaceLandmarker | null>(null);
+    const [isInitializing, setIsInitializing] = useState(true);
+
+    // State refs for the interval loop
+    const faceMissingTicks = useRef(0);
+    const eyeClosedTicks = useRef(0);
+    const isPenaltyRef = useRef(false);
+
+    // Constants for 5fps loop
+    const LOOP_INTERVAL_MS = 200;
+    const FACE_MISSING_THRESHOLD_TICKS = 15; // 3 seconds @ 5fps
+    const EYE_CLOSED_THRESHOLD_TICKS = 50; // 10 seconds @ 5fps
+    const EYE_CLOSED_SCORE_THRESHOLD = 0.4; // Blendshape score threshold
+
+    useEffect(() => {
+        let active = true;
+        let stream: MediaStream | null = null;
+        let intervalId: number | null = null;
+
+        const init = async () => {
+            try {
+                const vision = await FilesetResolver.forVisionTasks(
+                    "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.19/wasm"
+                );
+                landmarkerRef.current = await FaceLandmarker.createFromOptions(vision, {
+                    baseOptions: {
+                        modelAssetPath: `https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task`,
+                        delegate: "GPU"
+                    },
+                    outputFaceBlendshapes: true,
+                    runningMode: "VIDEO",
+                    numFaces: 1,
+                });
+
+                stream = await navigator.mediaDevices.getUserMedia({ video: true });
+                if (videoRef.current && active) {
+                    videoRef.current.srcObject = stream;
+                }
+
+                if (active) {
+                    setIsInitializing(false);
+                    startLoop();
+                }
+            } catch (err) {
+                console.error("Failed to initialize MediaPipe:", err);
+            }
+        };
+
+        const startLoop = () => {
+            intervalId = window.setInterval(() => {
+                if (!videoRef.current || !landmarkerRef.current || videoRef.current.readyState < 2) {
+                    return;
+                }
+
+                const results = landmarkerRef.current.detectForVideo(videoRef.current, performance.now());
+
+                if (!results.faceBlendshapes || results.faceBlendshapes.length === 0) {
+                    // Face missing
+                    faceMissingTicks.current++;
+                    if (faceMissingTicks.current >= FACE_MISSING_THRESHOLD_TICKS) {
+                        triggerPenalty();
+                    }
+                } else {
+                    // Face detected
+                    faceMissingTicks.current = 0;
+                    const blendshapes = results.faceBlendshapes[0].categories;
+                    const leftEyeBlink = blendshapes.find(b => b.categoryName === "eyeBlinkLeft")?.score ?? 0;
+                    const rightEyeBlink = blendshapes.find(b => b.categoryName === "eyeBlinkRight")?.score ?? 0;
+
+                    if (leftEyeBlink > EYE_CLOSED_SCORE_THRESHOLD && rightEyeBlink > EYE_CLOSED_SCORE_THRESHOLD) {
+                        eyeClosedTicks.current++;
+                        if (eyeClosedTicks.current >= EYE_CLOSED_THRESHOLD_TICKS) {
+                            triggerPenalty();
+                        }
+                    } else {
+                        // Eyes open
+                        eyeClosedTicks.current = 0;
+                        if (isPenaltyRef.current) {
+                            resolvePenalty();
+                        }
+                    }
+                }
+            }, LOOP_INTERVAL_MS);
+        };
+
+        const triggerPenalty = () => {
+            if (!isPenaltyRef.current) {
+                isPenaltyRef.current = true;
+                onSleepDetected();
+            }
+        };
+
+        const resolvePenalty = () => {
+            if (isPenaltyRef.current) {
+                isPenaltyRef.current = false;
+                onAwakeDetected();
+            }
+        };
+
+        init();
+
+        return () => {
+            active = false;
+            if (intervalId !== null) clearInterval(intervalId);
+            if (stream) stream.getTracks().forEach(t => t.stop());
+            if (landmarkerRef.current) landmarkerRef.current.close();
+        };
+    }, [onSleepDetected, onAwakeDetected]);
+
+    return { videoRef, isInitializing };
+}

--- a/lib/alarm/flow.ts
+++ b/lib/alarm/flow.ts
@@ -4,6 +4,7 @@ export type AppState =
   | "alarming"
   | "coding"
   | "monitoring"
+  | "penalty"
   | "cleared";
 
 export type AppRoute = "/" | "/waiting" | "/challenge" | "/monitoring";
@@ -14,6 +15,7 @@ export const STATE_TO_ROUTE: Record<AppState, AppRoute> = {
   alarming: "/challenge",
   coding: "/challenge",
   monitoring: "/monitoring",
+  penalty: "/monitoring",
   cleared: "/",
 };
 
@@ -21,7 +23,7 @@ export const ROUTE_ALLOWED_STATES: Record<AppRoute, AppState[]> = {
   "/": ["idle", "cleared"],
   "/waiting": ["waiting"],
   "/challenge": ["alarming", "coding"],
-  "/monitoring": ["monitoring"],
+  "/monitoring": ["monitoring", "penalty"],
 };
 
 const ALLOWED_TRANSITIONS: Record<AppState, AppState[]> = {
@@ -29,7 +31,8 @@ const ALLOWED_TRANSITIONS: Record<AppState, AppState[]> = {
   waiting: ["alarming"],
   alarming: ["coding"],
   coding: ["monitoring"],
-  monitoring: ["cleared"],
+  monitoring: ["cleared", "penalty"],
+  penalty: ["monitoring", "cleared"],
   cleared: ["waiting"],
 };
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@mediapipe/tasks-vision": "^0.10.19",
     "@monaco-editor/react": "^4.7.0",
     "monaco-editor": "^0.55.1",
     "next": "16.1.6",
@@ -17,11 +18,11 @@
     "zustand": "^5.0.11"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4",
-    "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
-    "eslint": "^9",
+    "@tailwindcss/postcss": "^4.0.0",
+    "@types/node": "^20.0.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "eslint": "^9.0.0",
     "eslint-config-next": "16.1.6",
     "tailwindcss": "^4",
     "typescript": "^5"

--- a/stores/alarmStore.ts
+++ b/stores/alarmStore.ts
@@ -7,14 +7,17 @@ import { canTransition, type AppState } from "@/lib/alarm/flow";
 export interface AlarmStore {
   state: AppState;
   challengeCode: string;
+  isSleepDetectionOn: boolean;
   transition(next: AppState): boolean;
   setChallengeCode(code: string): void;
+  setSleepDetectionOn(on: boolean): void;
   reset(): void;
 }
 
 export const useAlarmStore = create<AlarmStore>((set, get) => ({
   state: "idle",
   challengeCode: starterCode,
+  isSleepDetectionOn: true,
   transition: (next) => {
     const current = get().state;
     if (!canTransition(current, next)) {
@@ -27,6 +30,9 @@ export const useAlarmStore = create<AlarmStore>((set, get) => ({
   },
   setChallengeCode: (code) => {
     set({ challengeCode: code });
+  },
+  setSleepDetectionOn: (on: boolean) => {
+    set({ isSleepDetectionOn: on });
   },
   reset: () => {
     set({ state: "idle" });


### PR DESCRIPTION
## 概要
要件定義書（F-09）に基づき、PCのWebカメラを利用して顔と目を監視し、二度寝を検知するシステムを実装しました。

## 変更内容
- `@mediapipe/tasks-vision` パッケージを追加し、CDN経由で `FaceLandmarker` モデルをロードするカスタムフック ([useSleepDetection](cci:1://file:///c:/Users/oujoono/Alarm-clock-crap-code/components/useSleepDetection.ts:5:0-117:1)) を実装
- アプリ全体のステートに `isSleepDetectionOn` (検知機能のON/OFF) と `penalty` (ペナルティ状態) を追加 ([stores/alarmStore.ts](cci:7://file:///c:/Users/oujoono/Alarm-clock-crap-code/stores/alarmStore.ts:0:0-0:0), [lib/alarm/flow.ts](cci:7://file:///c:/Users/oujoono/Alarm-clock-crap-code/lib/alarm/flow.ts:0:0-0:0))
- Home画面 ([app/page.tsx](cci:7://file:///c:/Users/oujoono/Alarm-clock-crap-code/app/page.tsx:0:0-0:0)) に二度寝検知機能のON/OFFトグルを追加。ON時にカメラ権限を要求し、拒否された場合は強制的にOFFにする処理を追加
- Monitoring画面 ([app/monitoring/page.tsx](cci:7://file:///c:/Users/oujoono/Alarm-clock-crap-code/app/monitoring/page.tsx:0:0-0:0)) でカメラ映像を表示し、以下の条件でペナルティ状態への遷移・解除を行うロジックを統合
  - **顔消失検知**: 3秒間連続で顔が検出されない場合、ペナルティ移行
  - **閉眼検知**: 10秒間連続で両目が閉じている（Blendshape score > 0.4）と判定された場合、ペナルティ移行
  - 再び目を開ける、または顔が映るとペナルティ解除

## 確認手順
1. `npm install` を実行して依存パッケージをインストールする
2. `npm run dev` でローカルサーバーを起動
3. `http://localhost:3000` にアクセス
4. Home画面で「二度寝検知機能」のトグルをONにし、ブラウザのカメラ権限を許可する
5. 「Start Alarm」から Monitoring画面へ進む
6. 以下の動作で警告UI（ペナルティ）が表示されるか確認する：
   - カメラから3秒以上顔を逸らす
   - 10秒以上目を閉じる（または手で被う）

## 影響範囲
- `/` (Home画面)
- `/monitoring` (監視画面)
- [stores/alarmStore.ts](cci:7://file:///c:/Users/oujoono/Alarm-clock-crap-code/stores/alarmStore.ts:0:0-0:0)
- [lib/alarm/flow.ts](cci:7://file:///c:/Users/oujoono/Alarm-clock-crap-code/lib/alarm/flow.ts:0:0-0:0)

## 補足
一部の `any` 型のLintエラーも併せて修正しています。
