### PR TITLE
アラーム時刻保存とwaiting画面カウントダウン実装（簡易版）

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,11 +11,27 @@ import MobileConnection from "@/components/MobileConnection";
 
 export default function HomePage() {
   const router = useRouter();
+
+  // 現在の状態を取得（右側の MobileConnection に渡すために使う）
   const state = useAlarmStore((store: AlarmStore) => store.state);
+
+  // 二度寝検知のON/OFF状態を取得
   const isSleepDetectionOn = useAlarmStore((store: AlarmStore) => store.isSleepDetectionOn);
+
+  // 二度寝検知をON/OFFする関数
   const setSleepDetectionOn = useAlarmStore((store: AlarmStore) => store.setSleepDetectionOn);
+
+  // state を waiting / alarming などへ遷移させる関数
   const transition = useAlarmStore((store: AlarmStore) => store.transition);
+
+  // ストアを初期状態へ戻す関数
   const reset = useAlarmStore((store: AlarmStore) => store.reset);
+
+  // ★追加
+  // Home で設定したアラーム時刻を Zustand に保存するための関数
+  // waiting 画面ではこの値を読んで、カウントダウンを表示する
+  const setAlarmTime = useAlarmStore((store: AlarmStore) => store.setAlarmTime);
+
   const isDev = process.env.NODE_ENV !== "production";
 
   // 設定状態を1つのオブジェクトにまとめる
@@ -37,6 +53,21 @@ export default function HomePage() {
   };
 
   const startWaiting = () => {
+    // 追加
+    // アラーム時刻が空なら waiting に進ませない
+    // waiting 画面では alarmTime が必須なので、ここで最低限チェックする
+    if (!settings.alarmTime) {
+      alert("アラーム時刻を設定してください。");
+      return;
+    }
+
+    // 追加
+    // Home で入力された時刻を Zustand に保存する
+    // これを保存しておくことで、/waiting に遷移したあとも
+    // 設定した時刻を元にカウントダウンを開始できる
+    setAlarmTime(settings.alarmTime);
+
+    // 既存どおり、state を waiting に遷移させる
     const moved = transition("waiting");
     if (moved) {
       router.push("/waiting");
@@ -45,6 +76,13 @@ export default function HomePage() {
 
   const debugJumpToChallenge = () => {
     reset();
+
+    // 追加
+    // DEV で直接 challenge に飛ぶ場合でも、
+    // いま設定中の alarmTime を保存しておく
+    // （このPRでは waiting の動作確認にも使えるようにしておくと便利）
+    setAlarmTime(settings.alarmTime);
+
     const movedToWaiting = transition("waiting");
     if (!movedToWaiting) {
       return;
@@ -62,16 +100,22 @@ export default function HomePage() {
     
     if (nextState) {
       try {
+        // カメラ権限を事前に確認
         await navigator.mediaDevices.getUserMedia({ video: true });
+
+        // 権限が取れたら Zustand と settings の両方を ON にする
         setSleepDetectionOn(true);
         updateSetting("enableMonitoring", true);
       } catch (err) {
         console.error("Camera permission denied:", err);
+
+        // 権限拒否時は OFF に戻す
         setSleepDetectionOn(false);
         updateSetting("enableMonitoring", false);
         alert("カメラの許可が得られなかったため、二度寝検知機能をOFFにします。");
       }
     } else {
+      // OFF にする場合は Zustand と settings の両方を更新する
       setSleepDetectionOn(false);
       updateSetting("enableMonitoring", false);
     }

--- a/app/waiting/page.tsx
+++ b/app/waiting/page.tsx
@@ -1,50 +1,133 @@
 "use client";
 
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 
-import { useAlarmStore } from "@/stores/alarmStore";
+import { type AlarmStore, useAlarmStore } from "@/stores/alarmStore";
+import {
+  buildNextAlarmDate,
+  formatRemainingTime,
+  formatTargetTime,
+} from "@/lib/alarm/time";
 
 export default function WaitingPage() {
   const router = useRouter();
-  const state = useAlarmStore((store) => store.state);
-  const transition = useAlarmStore((store) => store.transition);
-  const reset = useAlarmStore((store) => store.reset);
 
-  const triggerAlarm = () => {
-    const moved = transition("alarming");
-    if (moved) {
-      router.push("/challenge");
+  // 現在の store 状態を表示確認用に取得
+  const state = useAlarmStore((store: AlarmStore) => store.state);
+
+  // Home で保存したアラーム時刻を取得
+  const alarmTime = useAlarmStore((store: AlarmStore) => store.alarmTime);
+
+  // state を alarming に進めるための関数
+  const transition = useAlarmStore((store: AlarmStore) => store.transition);
+
+  // Reset ボタン用
+  const reset = useAlarmStore((store: AlarmStore) => store.reset);
+
+  // 画面に表示する残り時間（ミリ秒）
+  const [remainingMs, setRemainingMs] = useState(0);
+
+  // 二重遷移防止用フラグ
+  // setInterval が複数回走ったり、diff <= 0 が続いたときに
+  // transition("alarming") を何度も呼ばないために使う
+  const triggeredRef = useRef(false);
+
+  // alarmTime ("HH:mm") から次に来る目標日時 Date を作る
+  const targetDate = useMemo(() => {
+    if (!alarmTime) return null;
+    return buildNextAlarmDate(alarmTime);
+  }, [alarmTime]);
+
+  useEffect(() => {
+    // alarmTime が無いまま waiting に来た場合は Home に戻す
+    if (!alarmTime || !targetDate) {
+      router.replace("/");
+      return;
     }
-  };
 
-  const backToHome = () => {
+    const updateRemaining = () => {
+      const diff = targetDate.getTime() - Date.now();
+
+      // 毎秒、残り時間を更新する
+      setRemainingMs(diff);
+
+      // 指定時刻に到達したら alarming に遷移して challenge へ移動する
+      // triggeredRef で二重実行を防ぐ
+      if (diff <= 0 && !triggeredRef.current) {
+        triggeredRef.current = true;
+
+        const moved = transition("alarming");
+        if (moved) {
+          router.replace("/challenge");
+        }
+      }
+    };
+
+    // 初回表示時にもすぐ1回実行する
+    // これがないと、画面表示から1秒待つまで表示が更新されない
+    updateRemaining();
+
+    // 1秒ごとに残り時間を更新する
+    const intervalId = window.setInterval(updateRemaining, 1000);
+
+    // ページ離脱時に interval を解除してメモリリークを防ぐ
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [alarmTime, router, targetDate, transition]);
+
+  const handleReset = () => {
+    // waiting 状態を解除して Home に戻す
     reset();
-    router.push("/");
+    router.replace("/");
   };
 
   return (
-    <main className="mx-auto flex min-h-screen max-w-2xl flex-col items-center justify-center gap-6 px-6 text-center">
-      <h1 className="text-3xl font-bold">Waiting</h1>
-      <p className="text-sm opacity-70">/waiting</p>
-      <p className="text-lg">
-        Current state: <span className="font-semibold">{state}</span>
-      </p>
-      <div className="flex gap-3">
-        <button
-          type="button"
-          onClick={triggerAlarm}
-          className="rounded bg-black px-4 py-2 text-white"
-        >
-          Trigger Alarm
-        </button>
-        <button
-          type="button"
-          onClick={backToHome}
-          className="rounded border border-black px-4 py-2"
-        >
-          Reset
-        </button>
+    <div className="min-h-screen bg-gray-900 text-white">
+      <div className="max-w-3xl mx-auto px-4 py-16">
+        <div className="rounded-2xl border border-gray-700 bg-gray-800 p-8 shadow-xl">
+          <div className="space-y-6 text-center">
+            <div>
+              <p className="text-sm text-gray-400">現在の状態</p>
+              <h1 className="mt-2 text-3xl font-bold">待機中</h1>
+            </div>
+
+            <div>
+              <p className="text-sm text-gray-400">設定時刻</p>
+              <p className="mt-2 text-xl font-semibold">
+                {targetDate ? formatTargetTime(targetDate) : "未設定"}
+              </p>
+            </div>
+
+            <div>
+              <p className="text-sm text-gray-400">アラームまで残り</p>
+              <p className="mt-2 text-5xl font-bold tracking-widest">
+                {formatRemainingTime(remainingMs)}
+              </p>
+            </div>
+
+            <p className="text-sm text-gray-400">
+              指定時刻になると challenge 画面へ移動します
+            </p>
+
+            <div className="rounded-lg bg-gray-900/50 p-4 text-left text-sm text-gray-400">
+              <p>store state: {state}</p>
+              <p>alarmTime: {alarmTime ?? "null"}</p>
+            </div>
+
+            <div className="pt-2">
+              <button
+                type="button"
+                onClick={handleReset}
+                className="rounded-lg border border-gray-600 px-4 py-2 text-gray-300 hover:bg-gray-700"
+              >
+                Reset
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
-    </main>
+    </div>
   );
 }

--- a/lib/alarm/time.ts
+++ b/lib/alarm/time.ts
@@ -1,0 +1,55 @@
+// lib/alarm/time.ts
+
+// "HH:mm" 形式の文字列から、次に来るアラーム日時を生成する関数
+// 例:
+//   現在 06:50 / alarmTime = "07:00" → 今日の 07:00
+//   現在 07:10 / alarmTime = "07:00" → 明日の 07:00
+export function buildNextAlarmDate(alarmTime: string): Date | null {
+  if (!alarmTime) return null;
+
+  const [hourText, minuteText] = alarmTime.split(":");
+  const hours = Number(hourText);
+  const minutes = Number(minuteText);
+
+  if (Number.isNaN(hours) || Number.isNaN(minutes)) {
+    return null;
+  }
+
+  const now = new Date();
+  const target = new Date();
+
+  // 今日の日付に対して、設定した時刻をセットする
+  target.setHours(hours, minutes, 0, 0);
+
+  // すでにその時刻を過ぎていたら、次の日の同時刻として扱う
+  if (target.getTime() <= now.getTime()) {
+    target.setDate(target.getDate() + 1);
+  }
+
+  return target;
+}
+
+// 残りミリ秒を "HH:mm:ss" 形式に整形する
+export function formatRemainingTime(ms: number): string {
+  const safeMs = Math.max(0, ms);
+  const totalSeconds = Math.floor(safeMs / 1000);
+
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  const pad = (num: number) => String(num).padStart(2, "0");
+
+  return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+}
+
+// 目標時刻を日本語の日時表示に整形する
+export function formatTargetTime(date: Date): string {
+  return date.toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/stores/alarmStore.ts
+++ b/stores/alarmStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { persist } from "zustand/middleware";
 
 import { starterCode } from "@/lib/alarm/challengeMock";
 import { getAlarmGateway } from "@/lib/alarm/gateway";
@@ -8,34 +9,83 @@ export interface AlarmStore {
   state: AppState;
   challengeCode: string;
   isSleepDetectionOn: boolean;
+
+  // 追加
+  // Home で設定したアラーム時刻（例: "07:00"）を保持する
+  // waiting 画面でこの値を読み、目標時刻までの残り時間を計算する
+  alarmTime: string | null;
+
   transition(next: AppState): boolean;
   setChallengeCode(code: string): void;
   setSleepDetectionOn(on: boolean): void;
+
+  // 追加
+  // アラーム時刻を保存する setter
+  setAlarmTime(alarmTime: string | null): void;
+
   reset(): void;
 }
 
-export const useAlarmStore = create<AlarmStore>((set, get) => ({
-  state: "idle",
-  challengeCode: starterCode,
-  isSleepDetectionOn: true,
-  transition: (next) => {
-    const current = get().state;
-    if (!canTransition(current, next)) {
-      return false;
-    }
+export const useAlarmStore = create<AlarmStore>()(
+  persist(
+    (set, get) => ({
+      state: "idle",
+      challengeCode: starterCode,
+      isSleepDetectionOn: true,
 
-    set({ state: next });
-    void getAlarmGateway().syncState(next).catch(() => undefined);
-    return true;
-  },
-  setChallengeCode: (code) => {
-    set({ challengeCode: code });
-  },
-  setSleepDetectionOn: (on: boolean) => {
-    set({ isSleepDetectionOn: on });
-  },
-  reset: () => {
-    set({ state: "idle" });
-    void getAlarmGateway().syncState("idle").catch(() => undefined);
-  },
-}));
+      // 追加
+      // 初期状態ではアラーム時刻は未設定
+      alarmTime: null,
+
+      transition: (next) => {
+        const current = get().state;
+        if (!canTransition(current, next)) {
+          return false;
+        }
+
+        set({ state: next });
+        void getAlarmGateway().syncState(next).catch(() => undefined);
+        return true;
+      },
+
+      setChallengeCode: (code) => {
+        set({ challengeCode: code });
+      },
+
+      setSleepDetectionOn: (on: boolean) => {
+        set({ isSleepDetectionOn: on });
+      },
+
+      // 追加
+      // Home で指定されたアラーム時刻を保存する
+      setAlarmTime: (alarmTime: string | null) => {
+        set({ alarmTime });
+      },
+
+      reset: () => {
+        set({
+          state: "idle",
+          challengeCode: starterCode,
+          isSleepDetectionOn: true,
+
+          // 追加
+          // リセット時はアラーム時刻も消す
+          alarmTime: null,
+        });
+        void getAlarmGateway().syncState("idle").catch(() => undefined);
+      },
+    }),
+    {
+      name: "alarm-store",
+
+      // ★追加
+      // リロード後も waiting の情報を維持できるように保存対象を指定する
+      partialize: (state) => ({
+        state: state.state,
+        challengeCode: state.challengeCode,
+        isSleepDetectionOn: state.isSleepDetectionOn,
+        alarmTime: state.alarmTime,
+      }),
+    }
+  )
+);


### PR DESCRIPTION
## 概要

アラーム時刻を保存し、waiting画面でカウントダウンを行う機能を追加しました。

指定した時刻になると自動で `alarming` 状態へ遷移し、challenge画面へ移動します。

## 変更内容

### store
- `alarmTime` を Zustand store に追加
- `setAlarmTime()` を追加
- persist を導入しリロード後も状態を保持

### Home (`app/page.tsx`)
- アラーム時刻を store に保存する処理を追加
- `アラーム設定を保存` ボタンで waiting に遷移

### waiting (`app/waiting/page.tsx`)
- 残り時間カウントダウン表示
- 1秒ごとのタイマー更新
- 時刻到達で `alarming` へ遷移
- `/challenge` へ自動移動

### time utils
新規追加:
- `lib/alarm/time.ts`
- `buildNextAlarmDate`
- `formatRemainingTime`
- `formatTargetTime`

## 動作確認

1. Home でアラーム時刻を設定
2. 「アラーム設定を保存」をクリック
3. `/waiting` に遷移
4. カウントダウンが表示される
5. 指定時刻になると `/challenge` に移動

## 今回含めないもの
- アラーム音再生
- Geminiレビュー
- Supabase同期
- スマホ連携