### PR TITLE
Geminiモデルの変更

### DIFF
--- a/app/api/generate-code/route.ts
+++ b/app/api/generate-code/route.ts
@@ -150,7 +150,7 @@ ${bad_patterns_text}
 `;
 
     const result = await ai.models.generateContent({
-      model: "gemini-1.5-flash",
+      model: "gemini-2.5-flash",
       contents: [
         { role: 'user', parts: [{ text: userPrompt }] }
       ],

--- a/app/api/review-code/route.ts
+++ b/app/api/review-code/route.ts
@@ -245,7 +245,7 @@ ${payload.patchedCode}
 `.trim();
 
   const response = await fetch(
-    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent?key=${apiKey}`,
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=${apiKey}`,
     {
       method: "POST",
       headers: {


### PR DESCRIPTION
### Geminiモデルの変更

1.5flash,2.0flashは終了済であったため、2.5flashに変更します。


**今後について**
太田さんより、動作が遅いという報告を受けました。
使用するAPIを変更するとしたら下記サービスがあるようです。

OpenRouter
- 無料モデル例（すべて $0/token）
- Qwen3-Coder 480B
- DeepSeek R1
- Llama 3.3 70B Instruct
- その他Mistral系・NVIDIA Nemotronなど24モデル以上無料

Groq
- 主な無料モデル
- Llama 3.3 70B / Llama 4 Scout
- Qwen3系（一部搭載）