### PR TITLE
UIからカメラプレビュー・モバイルコンポーネント（QRコードやステータス）の削除

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -169,9 +169,10 @@ export default function HomePage() {
             />
           </div>
 
-          <div>
+          {/*<div>
             <MobileConnection state={state} />
           </div>
+          */}
         </div>
 
         <div className="mt-8 flex justify-center">

--- a/components/AlarmConfig.tsx
+++ b/components/AlarmConfig.tsx
@@ -77,7 +77,7 @@ export default function AlarmConfig({
         </p>
       </div>
 
-      {/* カメラプレビュー */}
+      {/* { カメラプレビュー }
       {enableMonitoring && (
         <div className="mb-4">
           <label className="block text-sm font-medium text-gray-300 mb-2">
@@ -87,7 +87,7 @@ export default function AlarmConfig({
             <p className="text-gray-400 text-sm">カメラプレビュー表示領域</p>
           </div>
         </div>
-      )}
+      )} */}
     </div>
   );
 }


### PR DESCRIPTION
設定画面をスクロールなしで表示できるサイズに収めるため、カメラプレビュー部分をコメントアウトしました。

＊カメラプレビューは左上から見ることができます。